### PR TITLE
Update Description Card UI in the Nft page

### DIFF
--- a/infty/src/pages/NftPage.vue
+++ b/infty/src/pages/NftPage.vue
@@ -13,25 +13,15 @@
                         {{ (card && card.description) || "No description." }}
                     </p>
                 </b-card-text>
-                <b-list-group flush>
-                    <b-list-group-item>
-                        <b-button v-b-toggle.collapse-1 variant="outline-secondary" class="category-button"
-                            ><b-icon icon="file-earmark-richtext"></b-icon>About</b-button
+                <span
+                            class="badge badge-pill badge-info"
+                            style="display:inline-block;margin-right:5px;"
+                            v-for="(item, index) in card.labels"
+                            :key="index"
                         >
-                        <b-collapse id="collapse-1" class="mt-2">
-                            <p>
-                                This is supposed to be the description of the album
-                            </p>
-                            <span
-                                class="badge badge-pill badge-info"
-                                style="display:inline-block;margin-right:5px;"
-                                v-for="(item, index) in card.labels"
-                                :key="index"
-                            >
-                                {{ item }}
-                            </span>
-                        </b-collapse>
-                    </b-list-group-item>
+                            {{ item }}
+                </span>
+                <b-list-group flush>
                     <b-list-group-item>
                         <b-button v-b-toggle.collapse-2 variant="outline-secondary" class="category-button"
                             ><b-icon icon="file-earmark-text"></b-icon>Details</b-button
@@ -451,6 +441,7 @@ export default {
     }
 }
 .category-button {
+    margin-top: 2rem;
     width: 100%;
 }
 .heart {


### PR DESCRIPTION
**Demo**:

<img width="1272" alt="Screen Shot 2022-11-20 at 5 55 58 PM" src="https://user-images.githubusercontent.com/67870437/202931131-f946577f-a16a-4f61-869d-29ca89515da8.png">

**Changes**: 
1. remove the "About" section 
2. move tags outside