### PR TITLE
249 - improve minting process by forcing user to pay commission before minting

### DIFF
--- a/backend/src/controllers/nftController.js
+++ b/backend/src/controllers/nftController.js
@@ -103,7 +103,7 @@ async function createNft(req, res) {
     if (transaction == null){
         res.status(400).json({error: "given transaction is not valid"});
     }
-    const nftEpoch = await cfxUtils.getEpochNumebr(transaction.blockHash);
+    const nftEpoch = await cfxUtils.getEpochNumber(transaction.blockHash);
     const currentEpoch = await cfxUtils.getCurrentEpochNumber();
 
     // check if the transaction is happend within 60 epochs of the last mined nft

--- a/backend/src/controllers/nftController.js
+++ b/backend/src/controllers/nftController.js
@@ -95,14 +95,16 @@ async function createNft(req, res) {
     const mintEstimation = req.body.estimation;
     const transactionHash = req.body.receipt;
     const hashExpireTime = 600;
-
-    const transaction = await cfxUtils.getTransaction(transactionHash);
+    try{
+        const transaction = await cfxUtils.getTransaction(transactionHash);
+    } catch(e){
+        res.status(400).json({error: "given transaction is not valid"});
+    }
+    if (transaction == null){
+        res.status(400).json({error: "given transaction is not valid"});
+    }
     const nftEpoch = await cfxUtils.getEpochNumebr(transaction.blockHash);
     const currentEpoch = await cfxUtils.getCurrentEpochNumber();
-
-    // try catch getTransaction
-    // check if transaction == null
-
 
     // check if the transaction is happend within 60 epochs of the last mined nft
     if (currentEpoch - nftEpoch >= hashExpireTime){
@@ -386,30 +388,6 @@ async function purchaseNft(req, res) {
     res.status(200).send();
 }
 
-async function sendReceipt(req, res){
-    const body = req.body;
-    console.log("hash sent");
-    console.log(body.receipt);
-    const transaction = await cfxUtils.getTransaction(body.receipt);
-    console.log("transaction");
-    console.log(transaction);
-    
-    if (transcation.to != process.env.MANAGER_ADDRESS){
-        return res.status(400).json({error: "the commission fee is not paid properly" }); 
-    }
-    try {
-        const result = await User.findOneAndUpdate(
-            { address: transaction.from },
-            { $push: {paid_commisions: body.estimation} },
-            { new: true } )
-        console.log("receipt")
-        console.log(body.receipt)
-    } catch (error) {
-        return res.status(400).json({error: error.message });
-    }
-    return res.status(200).send();
-}
-
 module.exports = {
     getMarket,
     getNft,
@@ -423,5 +401,4 @@ module.exports = {
     likeNft,
     unlikeNft,
     validateNftOwnership,
-    sendReceipt,
 };

--- a/backend/src/models/user.js
+++ b/backend/src/models/user.js
@@ -11,6 +11,7 @@ const userSchema = new Schema(
         album_ids: { type: [{ address: String, percentage: Number }], default: [] },
         profile_picture: { type: String },
         liked_nfts: { type: [String], default: [] },
+        paid_commisions: {type: [Number]},
     },
     {
         timestamps: {

--- a/backend/src/models/user.js
+++ b/backend/src/models/user.js
@@ -11,7 +11,7 @@ const userSchema = new Schema(
         album_ids: { type: [{ address: String, percentage: Number }], default: [] },
         profile_picture: { type: String },
         liked_nfts: { type: [String], default: [] },
-        paid_commisions: {type: [Number]},
+        used_commission_hash: {type: [{epochNumber: Number, hash: String}]},
     },
     {
         timestamps: {

--- a/backend/src/routes/nftRouter.js
+++ b/backend/src/routes/nftRouter.js
@@ -27,5 +27,6 @@ router.post("/update-views/:nft_id", nftController.updateViews);
 router.post("/like-nft", nftController.likeNft);
 router.post("/unlike-nft", nftController.unlikeNft);
 router.post("/validate-nft", nftController.validateNftOwnership);
+router.post("/send-receipt", nftController.sendReceipt);
 
 module.exports = router;

--- a/backend/src/routes/nftRouter.js
+++ b/backend/src/routes/nftRouter.js
@@ -27,6 +27,5 @@ router.post("/update-views/:nft_id", nftController.updateViews);
 router.post("/like-nft", nftController.likeNft);
 router.post("/unlike-nft", nftController.unlikeNft);
 router.post("/validate-nft", nftController.validateNftOwnership);
-router.post("/send-receipt", nftController.sendReceipt);
 
 module.exports = router;

--- a/backend/src/utils/cfxUtils.js
+++ b/backend/src/utils/cfxUtils.js
@@ -113,7 +113,7 @@ async function getTransaction(hash){
     return await cfx.getTransactionByHash(hash);
 }
 
-async function getEpochNumebr(hash){
+async function getEpochNumber(hash){
     const block = await cfx.getBlockByHash(hash)
     return block.epochNumber;
 }
@@ -135,6 +135,6 @@ module.exports = {
     drawRaffle,
     decodeRaffleLog,
     getTransaction,
-    getEpochNumebr,
+    getEpochNumber,
     getCurrentEpochNumber,
 };

--- a/backend/src/utils/cfxUtils.js
+++ b/backend/src/utils/cfxUtils.js
@@ -109,6 +109,19 @@ async function actualTokenId(ownerAddr, uri) {
     return -1;
 }
 
+async function getTransaction(hash){
+    return await cfx.getTransactionByHash(hash);
+}
+
+async function getEpochNumebr(hash){
+    const block = await cfx.getBlockByHash(hash)
+    return block.epochNumber;
+}
+
+async function getCurrentEpochNumber(){
+    return await cfx.getEpochNumber('latest_mined');
+}
+
 module.exports = {
     mint,
     burn,
@@ -121,4 +134,7 @@ module.exports = {
     getOwnerOnChain,
     drawRaffle,
     decodeRaffleLog,
+    getTransaction,
+    getEpochNumebr,
+    getCurrentEpochNumber,
 };

--- a/infty/src/pages/CreatePage.vue
+++ b/infty/src/pages/CreatePage.vue
@@ -175,17 +175,16 @@ export default {
             if (error) {
                 return; // Stop to create nft if the transaction failed
             }
-            await axios.post(this.$store.getters.getApiUrl + "/send-receipt", {receipt, estimation})
-            .catch( e => {
-                console.log("error in sending receipt" + e)
-                Notification.closeAll();
-                this.$notify.error({
+            const receiptSent = await axios.post(this.$store.getters.getApiUrl + "/send-receipt", {receipt, estimation})
+            console.log(receiptSent)
+            if (receiptSent.status == 400){
+                 Notification.closeAll();
+                 this.$notify.error({
                         title: "Fail to send commision receipt to the backend",
-                        message: e,
+                        message: receiptSent.data.error,
                         duration: 3000,
                     });
-                return;
-            })
+            }
             console.log("finish sending receipt")
             // Create nft
             const fd = new FormData();

--- a/infty/src/pages/CreatePage.vue
+++ b/infty/src/pages/CreatePage.vue
@@ -146,6 +146,7 @@ export default {
             // Charge User
             const getters = this.$store.getters;
             this.$store.dispatch("notifyLoading", { msg: "Paying commission now" });
+            
             let error = false; // flag is set to true when errors occur in transaction
             const receipt = 
                 await this.$store.getters.getCfx

--- a/infty/src/pages/CreatePage.vue
+++ b/infty/src/pages/CreatePage.vue
@@ -175,17 +175,7 @@ export default {
             if (error) {
                 return; // Stop to create nft if the transaction failed
             }
-            const receiptSent = await axios.post(this.$store.getters.getApiUrl + "/send-receipt", {receipt, estimation})
-            console.log(receiptSent)
-            if (receiptSent.status == 400){
-                 Notification.closeAll();
-                 this.$notify.error({
-                        title: "Fail to send commision receipt to the backend",
-                        message: receiptSent.data.error,
-                        duration: 3000,
-                    });
-            }
-            console.log("finish sending receipt")
+            
             // Create nft
             const fd = new FormData();
             fd.append("file", this.imageData);
@@ -197,6 +187,7 @@ export default {
             fd.append("unlockable_image", this.ucImageStr? this.ucImageStr: "");
             fd.append("unlockable_text", this.ucDescription? this.ucDescription: "");
             fd.append("estimation", estimation);
+            fd.append("receipt", receipt.transactionHash);
 
             axios
                 .post(this.$store.getters.getApiUrl + "/create-nft", fd)

--- a/infty/src/pages/CreatePage.vue
+++ b/infty/src/pages/CreatePage.vue
@@ -141,6 +141,44 @@ export default {
                 duration: 0,
             });
 
+            // Obtain estimation
+            const estimation = (await axios.post(this.$store.getters.getApiUrl + "/mint-estimate")).data.gas;
+            // Charge User
+            const getters = this.$store.getters;
+            this.$store.dispatch("notifyLoading", { msg: "Paying commission now" });
+            
+            let error = false; // flag is set to true when errors occur in transaction
+            const receipt = 
+                await this.$store.getters.getCfx
+                    .sendTransaction({
+                        from: (await window.conflux.request({method:"cfx_requestAccounts"}))[0],
+                        to: getters.getManagerAddr,
+                        gasPrice: getters.getGasPrice,
+                        value: estimation,
+                    })
+                    .executed()
+                    .catch((e) => {
+                        Notification.closeAll();
+                        let title = "Transaction Failed";
+                        let message = "Transaction failed, please try again";
+                        if (e.code === 4001) {
+                            message = "User denied transaction signature";
+                        }
+                        this.$notify.error({
+                            title,
+                            message,
+                            duration: 3000,
+                        });
+                        error = true;
+                    });
+
+            if (error) {
+                return; // Stop to create nft if the transaction failed
+            }
+            await axios.post(this.$store.getters.getApiUrl + "/send-receipt", {receipt, estimation})
+            .catch( e => console.log("error in send receipt" + e))
+            console.log("finish sending receipt")
+            // Create nft
             const fd = new FormData();
             fd.append("file", this.imageData);
             fd.append("address", this.$store.getters.getAddress);
@@ -150,42 +188,8 @@ export default {
             fd.append("labels", JSON.stringify(selectedLabels));
             fd.append("unlockable_image", this.ucImageStr? this.ucImageStr: "");
             fd.append("unlockable_text", this.ucDescription? this.ucDescription: "");
+            fd.append("estimation", estimation);
 
-            // Obtain estimation
-            const estimation = (await axios.post(this.$store.getters.getApiUrl + "/mint-estimate")).data.gas;
-            // Charge User
-            const getters = this.$store.getters;
-            this.$store.dispatch("notifyLoading", { msg: "Paying commission now" });
-
-            let error = false; // flag is set to true when errors occur in transaction
-            await this.$store.getters.getCfx
-                .sendTransaction({
-                    from: (await window.conflux.request({method:"cfx_requestAccounts"}))[0],
-                    to: getters.getManagerAddr,
-                    gasPrice: getters.getGasPrice,
-                    value: estimation,
-                })
-                .executed()
-                .catch((e) => {
-                    Notification.closeAll();
-                    let title = "Transaction Failed";
-                    let message = "Transaction failed, please try again";
-                    if (e.code === 4001) {
-                        message = "User denied transaction signature";
-                    }
-                    this.$notify.error({
-                        title,
-                        message,
-                        duration: 3000,
-                    });
-                    error = true;
-                });
-
-            if (error) {
-                return; // Stop to create nft if the transaction failed
-            }
-
-            // Create nft
             axios
                 .post(this.$store.getters.getApiUrl + "/create-nft", fd)
                 .then((res) => {

--- a/infty/src/pages/CreatePage.vue
+++ b/infty/src/pages/CreatePage.vue
@@ -146,7 +146,6 @@ export default {
             // Charge User
             const getters = this.$store.getters;
             this.$store.dispatch("notifyLoading", { msg: "Paying commission now" });
-            
             let error = false; // flag is set to true when errors occur in transaction
             const receipt = 
                 await this.$store.getters.getCfx

--- a/infty/src/pages/CreatePage.vue
+++ b/infty/src/pages/CreatePage.vue
@@ -176,7 +176,15 @@ export default {
                 return; // Stop to create nft if the transaction failed
             }
             await axios.post(this.$store.getters.getApiUrl + "/send-receipt", {receipt, estimation})
-            .catch( e => console.log("error in send receipt" + e))
+            .catch( e => {
+                console.log("error in sending receipt" + e)
+                Notification.closeAll();
+                this.$notify.error({
+                        title: "Fail to send commision receipt to the backend",
+                        message: e,
+                        duration: 3000,
+                    });
+            })
             console.log("finish sending receipt")
             // Create nft
             const fd = new FormData();

--- a/infty/src/pages/CreatePage.vue
+++ b/infty/src/pages/CreatePage.vue
@@ -184,6 +184,7 @@ export default {
                         message: e,
                         duration: 3000,
                     });
+                return;
             })
             console.log("finish sending receipt")
             // Create nft


### PR DESCRIPTION
Some console.log() is left in the file and will be removed once the reviewer reviews it


Edit:
1. compare the epoch number of the transaction and the epoch number of the lastest-mined block in `sendReceipt`, and only store the transaction hash within 100 of the lasted-mined epoch number.
2. in `createNft`, delete the transaction hash that matches the estimated minting fee or return if there is no satisfied transaction in the database.

### Assumption
We assume that the transaction to our manager's address is within 100 of the lasted-mined epoch number

### Invariant
We ensure that the database stores a list of transaction hash of verified transactions that is completed recently (within 100 of the lasted-mined epoch number)

Since we verified in `sendReceipt` that the transaction is completed recently, the client can't use an old transaction with an epoch that is larger than 100 of the lasted-mined epoch number to pay the minting fee. Also, since we delete the transaction hash that matches the estimated minting fee, we ensure that no client could mint without paying the estimated minting fee recently.


